### PR TITLE
Fix: Show Mouse Events Setting and Crash Fixes (#10)

### DIFF
--- a/src/screencastkeys/__init__.py
+++ b/src/screencastkeys/__init__.py
@@ -22,7 +22,7 @@
 bl_info = {
     'name': 'Screencast Keys',
     'author': 'Paulo Gomes, Bart Crouch, John E. Herrenyo, '
-              'Gaia Clary, Pablo Vazquez, chromoly, Nutti',
+              'Gaia Clary, Pablo Vazquez, chromoly, Hawkpath, Nutti',
     'version': (3, 0, 0),
     'blender': (2, 80, 0),
     'location': '3D View > Properties Panel > Screencast Keys',

--- a/src/screencastkeys/ops.py
+++ b/src/screencastkeys/ops.py
@@ -188,6 +188,23 @@ class ScreencastKeysStatus(bpy.types.Operator):
         EventType.OSKEY
     ]
 
+    mouse_event_types = {
+        EventType.LEFTMOUSE,  # Left Mouse
+        EventType.MIDDLEMOUSE,  # Middle Mouse
+        EventType.RIGHTMOUSE,  # Right Mouse
+        EventType.BUTTON4MOUSE,  # Button4 Mouse
+        EventType.BUTTON5MOUSE,  # Button5 Mouse
+        EventType.BUTTON6MOUSE,  # Button6 Mouse
+        EventType.BUTTON7MOUSE,  # Button7 Mouse
+        EventType.TRACKPADPAN,  # Mouse/Trackpad Pan
+        EventType.TRACKPADZOOM,  # Mouse/Trackpad Zoom
+        EventType.MOUSEROTATE,  # Mouse/Trackpad Rotate
+        EventType.WHEELUPMOUSE,  # Wheel Up
+        EventType.WHEELDOWNMOUSE,  # Wheel Down
+        EventType.WHEELINMOUSE,  # Wheel In
+        EventType.WHEELOUTMOUSE,  # Wheel Out
+    }
+
     space_types = compat.get_all_space_types()
 
     SEPARATOR_HEIGHT = 0.6  # フォント高の倍率
@@ -565,11 +582,15 @@ class ScreencastKeysStatus(bpy.types.Operator):
 
         self.hold_modifier_keys.extend(mod_keys)
 
-    def is_ignore_event(self, event):
+    def is_ignore_event(self, event, prefs=None):
         event_type = EventType[event.type]
         if event_type in {EventType.NONE, EventType.MOUSEMOVE,
                           EventType.INBETWEEN_MOUSEMOVE,
                           EventType.WINDOW_DEACTIVATE, EventType.TEXTINPUT}:
+            return True
+        elif (prefs is not None
+              and not prefs.show_mouse_events
+              and event_type in self.mouse_event_types):
             return True
         elif event_type.name.startswith('EVT_TWEAK'):
             return True
@@ -586,6 +607,11 @@ class ScreencastKeysStatus(bpy.types.Operator):
         if not self.__class__.running:
             return {'FINISHED'}
 
+        if event.type == '':
+            # Many events that should (?) be identified as 'NONE' instead are
+            # identified as '' and raise KeyErrors in EventType
+            # (i.e. caps lock and the spin tool in edit mode)
+            return {'PASS_THROUGH'}
         event_type = EventType[event.type]
         current_time = time.time()
 
@@ -601,7 +627,7 @@ class ScreencastKeysStatus(bpy.types.Operator):
             current_mod.remove(event_type)
 
         # event_log
-        if (not self.is_ignore_event(event) and
+        if (not self.is_ignore_event(event, prefs=prefs) and
                 not self.is_modifier_event(event) and event.value == 'PRESS'):
             last = self.event_log[-1] if self.event_log else None
             current = [current_time, event_type, current_mod, 1]
@@ -636,7 +662,7 @@ class ScreencastKeysStatus(bpy.types.Operator):
 
         # redraw
         prev_time = self.prev_time
-        if (not self.is_ignore_event(event) or
+        if (not self.is_ignore_event(event, prefs=prefs) or
                 prev_time and current_time - prev_time >= self.TIMER_STEP):
             regions = self.find_redraw_regions(context)
 
@@ -820,7 +846,8 @@ class ScreencastKeysPanel(bpy.types.Panel):
         row.prop(prefs, 'offset')
         column.operator('wm.screencast_keys_set_origin',
                         text='Set Origin')
-        column.prop(prefs, 'show_last_operator', text='Last Operator')
+        column.prop(prefs, 'show_mouse_events')
+        column.prop(prefs, 'show_last_operator')
 
     @classmethod
     def register(cls):

--- a/src/screencastkeys/preferences.py
+++ b/src/screencastkeys/preferences.py
@@ -120,6 +120,10 @@ class ScreenCastKeysPreferences(bpy.types.AddonPreferences):
         step=10,
         subtype='TIME'
     )
+    show_mouse_events = bpy.props.BoolProperty(
+        name='Show Mouse Events',
+        default=True,
+    )
     show_last_operator = bpy.props.BoolProperty(
         name='Show Last Operator',
         default=False,
@@ -164,6 +168,7 @@ class ScreenCastKeysPreferences(bpy.types.AddonPreferences):
             col = split.column()
             col.prop(self, 'origin')
             col.prop(self, 'offset')
+            col.prop(self, 'show_mouse_events')
             col.prop(self, 'show_last_operator')
 
             self.layout.separator()


### PR DESCRIPTION
* Added setting to enable suppression of mouse event display
Changed show_last_operator name in 3D viewport panel to be consistent with its name in preferences
* Fix: crash when pressing caps lock and various edit mode tools

**Purpose of the pull request**  
*The purpose of the pull request. (e.g. Fix Bug, Feature request)*


**Description about the pull request**  
*The description about this pull request.*


**Additional comments** [Optional]  
